### PR TITLE
Simplify unindent & unindent!

### DIFF
--- a/lib/unindent.rb
+++ b/lib/unindent.rb
@@ -1,9 +1,9 @@
 class String
   def unindent
-    indent = self.split("\n").select {|line| !line.strip.empty? }.map {|line| line.index(/[^\s]/) }.compact.min || 0
-    self.gsub(/^[[:blank:]]{#{indent}}/, '')
+    indent = squeeze("\n").lines.map {|line| line.index(/[^\s]/) }.compact.min || 0
+    gsub(/^[[:blank:]]{#{indent}}/, '')
   end
   def unindent!
-    self.replace(self.unindent)
+    replace(unindent)
   end
 end


### PR DESCRIPTION
Simplifies script by using:

`squeeze` - to remove empty lines
`lines` - instead of `select

Removes unnecessary calls to `self`