### PR TITLE
Fix tests in Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,7 +1,3 @@
-def gem_opt
-  defined?(Gem) ? "-rubygems" : ""
-end
-
 # --------------------------------------------------
 # Tests
 # --------------------------------------------------
@@ -10,7 +6,7 @@ task(:default => :'test:all')
 namespace(:test) do
   desc "Run tests"
   task(:all) do
-    exit system("ruby #{gem_opt} -I.:lib test/test_unindent.rb")
+    exit system("ruby -I.:lib test/test_unindent.rb")
   end
 
   desc "Run tests on multiple ruby versions (requires rvm)"


### PR DESCRIPTION
`-rubygems` is interpreted as `-r ubygems` and generates the following error:

```
<internal:/usr/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require': cannot load such file -- ubygems (LoadError)
Did you mean?  rubygems
        from <internal:/usr/lib/ruby/3.0.0/rubygems/core_ext/kernel_require.rb>:85:in `require'
```

Probably it was needed for an ancient version of Ruby?

Removing it altogether works fine here.